### PR TITLE
Fixes gh-195: Updates to Node 6-compatible version of the midi package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Compatibility
 -------------
 
 Flocking is currently tested on the latest versions of Firefox, Chrome, Safari, and Microsoft Edge
-on Mac, Windows, Linux, iOS, and Android. Node.js 0.12.x is also supported.
+on Mac, Windows, Linux, iOS, and Android. Node.js 6.x is also supported.
 
 
 License

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "optionalDependencies": {
     "speaker": "colinbdclark/node-speaker#mpg123-lower-latency",
-    "midi": "0.9.4"
+    "midi": "0.9.5"
   },
   "engines": {
     "node": ">=0.10.x"


### PR DESCRIPTION
This PR address build failures in the midi library when using Node 6.