### PR TITLE
Fixes gh-174: Removes logging of the entire 'root' object when path parse errors occur.

### DIFF
--- a/dist/flocking-all.js
+++ b/dist/flocking-all.js
@@ -22045,7 +22045,7 @@ var fluid = fluid || require("infusion"),
 
     flock.pathParseError = function (root, path, token) {
         var msg = "Error parsing path '" + path + "'. Segment '" + token +
-            "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(root);
+            "' could not be resolved.";
 
         flock.fail(msg);
     };

--- a/dist/flocking-all.min.js
+++ b/dist/flocking-all.min.js
@@ -7644,7 +7644,7 @@ var flock = (fluid = fluid || require("infusion")).registerNamespace("flock");
         if (flock.debug.failHard) throw new Error(e);
         flock.log.fail(e);
     }, flock.pathParseError = function(e, t, n) {
-        var r = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(e);
+        var r = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved.";
         flock.fail(r);
     }, flock.get = function(e, t) {
         if (!e) return fluid.getGlobalValue(t);

--- a/dist/flocking-base.js
+++ b/dist/flocking-base.js
@@ -2058,7 +2058,7 @@ var fluid = fluid || require("infusion"),
 
     flock.pathParseError = function (root, path, token) {
         var msg = "Error parsing path '" + path + "'. Segment '" + token +
-            "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(root);
+            "' could not be resolved.";
 
         flock.fail(msg);
     };

--- a/dist/flocking-base.min.js
+++ b/dist/flocking-base.min.js
@@ -655,7 +655,7 @@ var flock = (fluid = fluid || require("infusion")).registerNamespace("flock");
         if (flock.debug.failHard) throw new Error(e);
         flock.log.fail(e);
     }, flock.pathParseError = function(e, t, n) {
-        var o = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(e);
+        var o = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved.";
         flock.fail(o);
     }, flock.get = function(e, t) {
         if (!e) return fluid.getGlobalValue(t);

--- a/dist/flocking-no-jquery.js
+++ b/dist/flocking-no-jquery.js
@@ -11247,7 +11247,7 @@ var fluid = fluid || require("infusion"),
 
     flock.pathParseError = function (root, path, token) {
         var msg = "Error parsing path '" + path + "'. Segment '" + token +
-            "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(root);
+            "' could not be resolved.";
 
         flock.fail(msg);
     };

--- a/dist/flocking-no-jquery.min.js
+++ b/dist/flocking-no-jquery.min.js
@@ -4468,8 +4468,8 @@
             if (i.debug.failHard) throw new Error(e);
             i.log.fail(e);
         }, i.pathParseError = function(e, t, n) {
-            var a = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved. Root object was: " + r.prettyPrintJSON(e);
-            i.fail(a);
+            var r = "Error parsing path '" + t + "'. Segment '" + n + "' could not be resolved.";
+            i.fail(r);
         }, i.get = function(e, t) {
             if (!e) return r.getGlobalValue(t);
             if (1 === arguments.length && "string" == typeof e) return r.getGlobalValue(e);

--- a/src/core.js
+++ b/src/core.js
@@ -659,7 +659,7 @@ var fluid = fluid || require("infusion"),
 
     flock.pathParseError = function (root, path, token) {
         var msg = "Error parsing path '" + path + "'. Segment '" + token +
-            "' could not be resolved. Root object was: " + fluid.prettyPrintJSON(root);
+            "' could not be resolved.";
 
         flock.fail(msg);
     };

--- a/tests/unit/js/synth-tests.js
+++ b/tests/unit/js/synth-tests.js
@@ -750,4 +750,25 @@ var fluid = fluid || require("infusion"),
         s.set("seq.list", newList);
         jqUnit.assertDeepEq("After setting a 'special input' on a unit generator, it should have been set correctly.", newList, seqUGen.inputs.list);
     });
+
+
+    jqUnit.module("Synth get() error tests");
+
+    jqUnit.test("Calling Synth.get() with an invalid path should immediately raise an error.", function () {
+        flock.debug.failHard = true;
+
+        var s = flock.synth({
+            synthDef: {
+                ugen: "flock.ugen.sinOsc"
+            }
+        });
+
+        try {
+            s.get("cat.dog");
+            jqUnit.fail("An error should have been raised when calling Synth.get() with an invalid key path.");
+        } catch (err) {
+            jqUnit.assertTrue("An error should have been raised when calling Synth.get() with an invalid key path.", err.message.indexOf("'cat' could not be resolved") > -1);
+        }
+    });
+
 }());


### PR DESCRIPTION
This is a relatively low-cost simple fix for gh-174, where we simply stop logging the "root" object. Users are still provided with information about which path segment failed, and this solves the issue of huge time delays spent in <code>fluid.prettyPrintJSON</code> for Flocking's (unfortunately) very circularly-referenced objects.