### PR TITLE
Fixes gh-230: Configures testem to launch Chrome without the user gesture autoplay policy.

### DIFF
--- a/tests/unit/testem.json
+++ b/tests/unit/testem.json
@@ -4,7 +4,12 @@
     "skip": "IE",
     "browser_args": {
         "Chrome": [
-            "--no-sandbox"
+            "--no-sandbox",
+            "--autoplay-policy=no-user-gesture-required"
+        ],
+        "Chrome Canary": [
+            "--no-sandbox",
+            "--autoplay-policy=no-user-gesture-required"
         ]
     }
 }


### PR DESCRIPTION
This should fix the test failures we are experiencing related to the use of a MediaStreamSourceNode and an Audio element without user interaction.