### PR TITLE
Fixes gh-235: Fixes test failures in Safari

### DIFF
--- a/tests/unit/js/flocking-test-utils.js
+++ b/tests/unit/js/flocking-test-utils.js
@@ -807,49 +807,13 @@ var fluid = fluid || require("infusion"),
     });
 
 
-    fluid.defaults("flock.test.synth.genReporter", {
-        gradeNames: ["flock.synth"],
-
-        model: {
-            didGen: false
-        },
-
-        members: {
-            genFn: "{that}.gen"
-        },
-
+    fluid.defaults("flock.test.silentSynth", {
+        gradeNames: "flock.synth",
         synthDef: {
             ugen: "flock.ugen.silence"
-        },
-
-        invokers: {
-            gen: {
-                changePath: "didGen",
-                value: true
-            },
-
-            reset: {
-                changePath: "didGen",
-                value: false
-            }
         }
     });
 
-    flock.test.synth.genReporter.assertWasEvaluated = function (synth) {
-        jqUnit.assertTrue("The synth should have been added to the environment.",
-        synth.isPlaying());
-
-        jqUnit.assertTrue("The synth should have been evaluated.",
-        synth.model.didGen);
-    };
-
-    flock.test.synth.genReporter.assertWasNotEvaluated = function (synth) {
-        jqUnit.assertFalse("The synth should have been added to the environment.",
-        synth.isPlaying());
-
-        jqUnit.assertFalse("The synth should have been evaluated.",
-        synth.model.didGen);
-    };
 
     flock.test.synthDefs = {
         amplitudeModulation: {

--- a/tests/unit/js/synth-environment-tests.js
+++ b/tests/unit/js/synth-environment-tests.js
@@ -15,12 +15,6 @@ var fluid = fluid || require("infusion"),
 (function () {
     "use strict";
 
-    flock.test.synth.testEnviroGraph = function (fn) {
-        setTimeout(function () {
-            fn();
-        }, 2000);
-    };
-
     fluid.defaults("flock.test.synth.environmental.autoAddTests", {
         gradeNames: "flock.test.module.runOnCreate",
 
@@ -29,12 +23,12 @@ var fluid = fluid || require("infusion"),
         components: {
             autoAddedSynth: {
                 createOnEvent: "afterEnvironmentCreated",
-                type: "flock.test.synth.genReporter"
+                type: "flock.test.silentSynth"
             },
 
             notAutoAddedSynth: {
                 createOnEvent: "afterEnvironmentCreated",
-                type: "flock.test.synth.genReporter",
+                type: "flock.test.silentSynth",
                 options: {
                     addToEnvironment: false
                 }
@@ -50,17 +44,9 @@ var fluid = fluid || require("infusion"),
     });
 
     flock.test.synth.environmental.autoAddTests.run = function (module) {
-        jqUnit.asyncTest("Auto add to the environment", function () {
-            module.environment.start();
-
-            flock.test.synth.testEnviroGraph(function () {
-                flock.test.synth.genReporter.assertWasEvaluated(module.autoAddedSynth);
-            });
-
-            flock.test.synth.testEnviroGraph(function () {
-                flock.test.synth.genReporter.assertWasNotEvaluated(module.notAutoAddedSynth);
-                jqUnit.start();
-            });
+        jqUnit.test("Auto add to the environment", function () {
+            jqUnit.assertTrue("A synth with default options should be automatically added to the environment at creation time.", module.environment.nodeList.nodes.includes(module.autoAddedSynth));
+            jqUnit.assertFalse("A synth with addToEnvironment set to false should not be automatically added to the environment at creation time.", module.environment.nodeList.nodes.includes(module.notAutoAddedSynth));
         });
     };
 

--- a/tests/unit/js/synth-removal-tests.js
+++ b/tests/unit/js/synth-removal-tests.js
@@ -19,7 +19,7 @@ flock = fluid.registerNamespace("flock");
 
         components: {
             synth: {
-                type: "flock.test.synth.genReporter",
+                type: "flock.test.silentSynth",
                 options: {
                     components: {
                         enviro: "{removeDestroyTests}.environment"
@@ -36,73 +36,43 @@ flock = fluid.registerNamespace("flock");
     fluid.defaults("flock.test.synth.environment.removeDestroyTester", {
         gradeNames: "fluid.test.testCaseHolder",
 
-        invokers: {
-            evaluate2Secs: {
-                funcName: "flock.test.synth.environment.removeDestroyTester.evaluate2Secs",
-                args: ["{testEnvironment}", "{that}.events.afterTwoSeconds.fire"]
-            }
-        },
-
-        events: {
-            afterTwoSeconds: null
-        },
-
         modules: [
             {
                 name: "Synth environmental tests",
                 tests: [
                     {
-                        expect: 5,
+                        expect: 2,
                         name: "Remove synth from the environment",
                         sequence: [
                             {
-                                func: "{environment}.play"
-                            },
-                            {
-                                func: "{that}.evaluate2Secs"
-                            },
-                            {
-                                event: "{that}.events.afterTwoSeconds",
-                                listener: "flock.test.synth.environment.removeDestroyTester.synthWasEvaluated"
+                                funcName: "flock.test.synth.environment.removeDestroyTester.assertSynthWasAdded",
+                                args: "{testEnvironment}"
                             },
                             {
                                 func: "{synth}.pause"
                             },
                             {
-                                funcName: "flock.test.synth.environment.removeDestroyTester.synthWasRemoved",
+                                funcName: "flock.test.synth.environment.removeDestroyTester.assertSynthWasRemoved",
                                 args: ["{testEnvironment}"]
-                            },
-                            {
-                                func: "{synth}.reset"
-                            },
-                            {
-                                func: "{that}.evaluate2Secs"
-                            },
-                            {
-                                event: "{that}.events.afterTwoSeconds",
-                                listener: "flock.test.synth.environment.removeDestroyTester.synthWasNotEvaluated"
                             }
                         ]
                     },
                     {
-                        expect: 3,
+                        expect: 2,
                         name: "Destroying a synth removes it from the environment",
                         sequence: [
                             {
                                 func: "{synth}.play"
                             },
                             {
-                                func: "{that}.evaluate2Secs"
-                            },
-                            {
-                                event: "{that}.events.afterTwoSeconds",
-                                listener: "flock.test.synth.environment.removeDestroyTester.synthWasEvaluated"
+                                funcName: "flock.test.synth.environment.removeDestroyTester.assertSynthWasAdded",
+                                args: "{testEnvironment}"
                             },
                             {
                                 func: "{synth}.destroy"
                             },
                             {
-                                funcName: "flock.test.synth.environment.removeDestroyTester.synthWasRemoved",
+                                funcName: "flock.test.synth.environment.removeDestroyTester.assertSynthWasRemoved",
                                 args: ["{testEnvironment}"]
                             }
                         ]
@@ -112,27 +82,16 @@ flock = fluid.registerNamespace("flock");
         ]
     });
 
-    flock.test.synth.environment.removeDestroyTester.evaluate2Secs = function (testEnvironment, testFn) {
-        var audioSettings = testEnvironment.environment.audioSystem.model;
-        var waitDur = (audioSettings.bufferSize / audioSettings.rates.audio) * 1000 * 2;
-
-        setTimeout(function () {
-            testFn(testEnvironment);
-        }, waitDur);
+    flock.test.synth.environment.removeDestroyTester.assertSynthWasAdded = function (testEnvironment) {
+        jqUnit.assertTrue(
+            "The synth should have been added to the environment.",
+            testEnvironment.environment.nodeList.nodes.includes(testEnvironment.synth));
     };
 
-    flock.test.synth.environment.removeDestroyTester.synthWasEvaluated = function (testEnvironment) {
-        flock.test.synth.genReporter.assertWasEvaluated(testEnvironment.synth);
-    };
-
-    flock.test.synth.environment.removeDestroyTester.synthWasRemoved = function (testEnvironment) {
-        jqUnit.assertEquals("The synth should have been removed from the environment.",
-        testEnvironment.environment.nodeList.nodes.indexOf(testEnvironment.synth),
-        -1);
-    };
-
-    flock.test.synth.environment.removeDestroyTester.synthWasNotEvaluated = function (testEnvironment) {
-        flock.test.synth.genReporter.assertWasNotEvaluated(testEnvironment.synth);
+    flock.test.synth.environment.removeDestroyTester.assertSynthWasRemoved = function (testEnvironment) {
+        jqUnit.assertFalse(
+            "The synth should have been removed from the environment.",
+            testEnvironment.environment.nodeList.nodes.includes(testEnvironment.synth));
     };
 
     fluid.test.runTests("flock.test.synth.environment.removeDestroyTests");


### PR DESCRIPTION
This PR removes environmental-related assumptions from some synth tests, which were failing in Safari due to its strict user interaction requirements.