### PR TITLE
gh-180: Adds support for file URLs when loading audio files in Node.js

### DIFF
--- a/demos/nodejs/audio-file.js
+++ b/demos/nodejs/audio-file.js
@@ -21,7 +21,7 @@ flock.synth({
         ugen: "flock.ugen.playBuffer",
         buffer: {
             id: "hillier-first-chord",
-            url: currentDir + "/../../demos/shared/audio/hillier-first-chord.wav"
+            url: "file:///" + currentDir + "/../../demos/shared/audio/hillier-first-chord.wav"
         },
         loop: 1,
         speed: {

--- a/demos/nodejs/write-audio.js
+++ b/demos/nodejs/write-audio.js
@@ -19,7 +19,7 @@ var granularDef = {
     ugen: "flock.ugen.triggerGrains",
     buffer: {
         id: "hillier-first-chord",
-        url: currentDir + "/../../demos/shared/audio/hillier-first-chord.wav"
+        url: "file:///" + currentDir + "/../../demos/shared/audio/hillier-first-chord.wav"
     },
     centerPos: {
         ugen: "flock.ugen.lfNoise",

--- a/src/nodejs/audio-system.js
+++ b/src/nodejs/audio-system.js
@@ -43,16 +43,17 @@ fluid.defaults("flock.nodejs.audioSystem", {
 fluid.registerNamespace("flock.file");
 
 flock.file.readFromPath = function (options) {
-    var path = options.src;
+    var path = options.src,
+        fileURL = new url.URL(path);
 
-    fs.exists(path, function (exists) {
+    fs.exists(fileURL, function (exists) {
         if (!exists && options.error) {
             options.error(path + " doesn't exist.");
             return;
         }
 
-        fs.stat(path, function (error, stats) {
-            fs.open(path, "r", function (error, fd) {
+        fs.stat(fileURL, function (error, stats) {
+            fs.open(fileURL, "r", function (error, fd) {
                 var buf = new Buffer(stats.size);
 
                 fs.read(fd, buf, 0, buf.length, null, function () {
@@ -80,7 +81,7 @@ flock.audio.loadBuffer.readerForSource = function (src) {
     }
     var parsed = url.parse(src);
     return parsed.protocol === "data:" ? flock.file.readBufferFromDataUrl :
-        !parsed.protocol ? flock.file.readFromPath : flock.net.readBufferFromUrl;
+        !parsed.protocol || parsed.protocol === "file:" ? flock.file.readFromPath : flock.net.readBufferFromUrl;
 };
 
 fluid.registerNamespace("flock.audio.decode");

--- a/tests/unit/js/buffer-tests.js
+++ b/tests/unit/js/buffer-tests.js
@@ -234,7 +234,7 @@ var fluid = fluid || require("infusion"),
             },
             {
                 id: "fish",
-                url: flock.test.pathForResource("../../../demos/shared/audio/hillier-first-chord.wav")
+                url: flock.test.urlForResource("../../../demos/shared/audio/hillier-first-chord.wav")
             }
         ];
 

--- a/tests/unit/js/buffer-ugen-tests.js
+++ b/tests/unit/js/buffer-ugen-tests.js
@@ -104,7 +104,7 @@ var fluid = fluid || require("infusion"),
             bufferDefs: [
                 {
                     id: "honey",
-                    url: flock.test.pathForResource("../../../demos/shared/audio/hillier-first-chord.wav")
+                    url: flock.test.urlForResource("../../../demos/shared/audio/hillier-first-chord.wav")
                 }
             ],
             listeners: {

--- a/tests/unit/js/flocking-test-utils.js
+++ b/tests/unit/js/flocking-test-utils.js
@@ -27,13 +27,13 @@ var fluid = fluid || require("infusion"),
         return new Float32Array(blockSize * 2);
     };
 
-    flock.test.pathForResource = function (path) {
-        return flock.platform.isBrowser ? path : __dirname + "/" + path;
+    flock.test.urlForResource = function (path) {
+        return flock.platform.isBrowser ? path : "file:///" + __dirname + "/" + path;
     };
 
     flock.test.audioFilePath = function (fileName) {
         var relativePath = "../../shared/audio/" + fileName;
-        return flock.test.pathForResource(relativePath);
+        return flock.test.urlForResource(relativePath);
     };
 
     // TODO: Promote this to core.


### PR DESCRIPTION
Due to support in more recent versions of Node.js for WHATWG URL objects in the file system API, this PR ensures that we can unambiguously detect file paths and load them correctly, even on Windows. Node.js users are thus recommended to use <code>file://</code> URLs when specifying a file <code>src</code> property to load.