### PR TITLE
Fixes gh-244: Removes non-JSON demos. Ensures all live demos work.

### DIFF
--- a/demos/playground/live/demos/chop-buffer.json
+++ b/demos/playground/live/demos/chop-buffer.json
@@ -1,0 +1,40 @@
+{
+    "synthDef": {
+        "id": "chopper",
+        "ugen": "flock.ugen.chopBuffer",
+        "start": 0.1,
+        "amount": {
+            "ugen": "flock.ugen.triOsc",
+            "rate": "control",
+            "freq": 0.03333333,
+            "mul": 0.5,
+            "add": 0.5
+        },
+        "speed": {
+            "ugen": "flock.ugen.lfNoise",
+            "rate": "audio",
+            "options": {
+                "interpolation": "linear"
+            },
+            "freq": 0.2,
+            "mul": 0.5,
+            "add": 0.5
+        },
+        "minDuration": {
+            "ugen": "flock.ugen.lfNoise",
+            "freq": 0.2,
+            "mul": 0.5,
+            "add": 0.001
+        },
+        "gap": -0.001,
+        "buffer": {
+            "url": "../../shared/audio/where-the-honey-is.mp3"
+        },
+
+        "mul": 0.1,
+
+        "options": {
+            "maxVoices": 10
+        }
+    }
+}

--- a/demos/playground/live/demos/declarative-scheduling.json
+++ b/demos/playground/live/demos/declarative-scheduling.json
@@ -1,0 +1,58 @@
+{
+    "components": {
+        "sinSynth": {
+            "type": "flock.synth",
+            "options": {
+                "synthDef": {
+                    "id": "carrier",
+                    "ugen": "flock.ugen.sinOsc",
+                    "freq": 220,
+                    "mul": {
+                        "ugen": "flock.ugen.line",
+                        "start": 0,
+                        "end": 0.25,
+                        "duration": 1.0
+                    }
+                }
+            }
+        },
+
+        "scheduler": {
+            "type": "flock.scheduler.async",
+            "options": {
+                "components": {
+                    "synthContext": "{sinSynth}"
+                },
+
+                "score": [
+                    {
+                        "interval": "repeat",
+                        "time": 1.0,
+                        "change": {
+                            "values": {
+                                "carrier.freq": {
+                                    "synthDef": {
+                                        "ugen": "flock.ugen.sequence",
+                                        "values": [330, 440, 550, 660, 880, 990, 1100, 1210]
+                                    }
+                                }
+                            }
+                        }
+                    },
+
+                    {
+                        "interval": "once",
+                        "time": 8,
+                        "change": {
+                            "values": {
+                                "carrier.mul.start": 0.25,
+                                "carrier.mul.end": 0.0,
+                                "carrier.mul.duration": 1.0
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/demos/playground/live/demos/latch.json
+++ b/demos/playground/live/demos/latch.json
@@ -18,7 +18,7 @@
                 "mul": 500,
                 "add": 600
             },
-            "trig": {
+            "trigger": {
                 "ugen": "flock.ugen.impulse",
                 "rate": "control",
                 "freq": 10

--- a/demos/playground/live/index.html
+++ b/demos/playground/live/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Flocking Playground</title>
+        <title>Flocking Live Playground</title>
 
         <link rel="stylesheet" href="../../../node_modules/normalize.css/normalize.css" />
         <link rel="stylesheet" href="../../../node_modules/codemirror/lib/codemirror.css" />
@@ -107,6 +107,8 @@
         <script src="../js/source-evaluators.js"></script>
         <script src="../js/demo-list.js"></script>
         <script src="js/visual-editor.js"></script>
+        <script src="js/live-demo-list.js"></script>
+
     </head>
 
     <body>

--- a/demos/playground/live/js/live-demo-list.js
+++ b/demos/playground/live/js/live-demo-list.js
@@ -125,6 +125,10 @@ var fluid = fluid || require("infusion");
                             "name": "Read buffer with phasor"
                         },
                         {
+                            "id": "chop-buffer",
+                            "name": "Chop a buffer"
+                        },
+                        {
                             "id": "audio-in",
                             "name": "Live audio input"
                         },
@@ -152,7 +156,7 @@ var fluid = fluid || require("infusion");
                         },
                         {
                             "id": "bandreject-filter",
-                            "name": "Band pass filter"
+                            "name": "Band reject filter"
                         },
                         {
                             "id": "delay",
@@ -274,6 +278,10 @@ var fluid = fluid || require("infusion");
                             "name": "Sequencer"
                         },
                         {
+                            "id": "declarative-scheduling",
+                            "name": "Declarative scheduling"
+                        },
+                        {
                             "id": "sample-accurate-scheduling",
                             "name": "Sample-accurate scheduling"
                         }
@@ -282,7 +290,7 @@ var fluid = fluid || require("infusion");
 
             ],
 
-            defaultOption: "granulator"
+            defaultOption: "bandpass-filter"
         }
     });
 }());

--- a/demos/playground/live/js/visual-editor.js
+++ b/demos/playground/live/js/visual-editor.js
@@ -115,6 +115,10 @@ var fluid = fluid || require("infusion"),
 
             playButtonManager: {
                 type: "flock.playground.playToggler"
+            },
+
+            demos: {
+                type: "flock.playground.demos.live"
             }
         },
 


### PR DESCRIPTION
This pull request:

- Adds missing demos ("Chop a buffer" and "Declarative Scheduling")
- Ensures that the live demo list component is used instead of the default
- Updates the "Sample and Hold" to the latest API for the latch unit generator