### PR TITLE
Fixes gh-245: Disables JSPlumb's endpoint draggability.

### DIFF
--- a/demos/playground/live/js/visual-editor.js
+++ b/demos/playground/live/js/visual-editor.js
@@ -646,31 +646,37 @@ var fluid = fluid || require("infusion"),
                 return;
             }
 
+            var sourceEndpoint = plumb.addEndpoint(edge.target, {
+                anchor: "Bottom",
+                width: 2,
+                endpoint: [
+                    "Dot",
+                    {
+                        radius: 4
+                    }
+                ]
+            });
+            sourceEndpoint.setEnabled(false);
+
+            var targetEndpoint = plumb.addEndpoint(edge.source, {
+                endpoint: [
+                    "Dot",
+                    {
+                        radius: 4
+                    }
+                ],
+                anchor: [
+                    "Perimeter",
+                    {
+                        shape: "Rectangle",
+                    }
+                ]
+            });
+            targetEndpoint.setEnabled(false);
+
             plumb.connect({
-                source: plumb.addEndpoint(edge.target, {
-                    anchor: "Bottom",
-                    width: 2,
-                    endpoint: [
-                        "Dot",
-                        {
-                            radius: 4
-                        }
-                    ]
-                }),
-                target: plumb.addEndpoint(edge.source, {
-                    endpoint: [
-                        "Dot",
-                        {
-                            radius: 4
-                        }
-                    ],
-                    anchor: [
-                        "Perimeter",
-                        {
-                            shape: "Rectangle",
-                        }
-                    ]
-                }),
+                source: sourceEndpoint,
+                target: targetEndpoint,
                 connector: "Straight",
                 overlays: [
                     [


### PR DESCRIPTION
By default JSPlumb endpoints are draggable, and cause the connected edge to be removed from the DOM. This PR disables JSPlumb's endpoints, thus ensuring they aren't draggable in the live playground.