### PR TITLE
Fixes gh-248: Updates the Flocking website for 1.0.0.

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
         <title>Flocking: Creative Audio Synthesis for the Web!</title>
         <link rel="stylesheet" type="text/css" href="flocking-website.css" />
         <link rel="shortcut icon" href="favicon.ico" />
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     </head>
     <body>
         <img class="logo" src="images/flocking-tentative-logo.png" alt="Flocking logo" />
@@ -16,7 +16,7 @@
 
         <p>Flocking is a JavaScript audio synthesis framework designed for artists and musicians
         who are building creative and experimental Web-based sound projects.
-        It runs in Firefox, Chrome, Safari, and Node.js on
+        It runs in Firefox, Chrome, Safari, Edge, and Node.js on
         Mac OS X, Windows, Linux, iOS, and Android.</p>
 
         <p>Flocking is different. Its goal is to promote a uniquely
@@ -41,22 +41,22 @@
         (2014).</p>
 
         <p>The latest stable release of Flocking is
-        <a href="https://github.com/colinbdclark/Flocking/releases/tag/0.1.2">version 0.1.2</a>.
+        <a href="https://github.com/colinbdclark/Flocking/releases/tag/1.0.0">version 1.0.0</a>.
         It is distributed under both the MIT and GPL licenses.</p>
 
         <ul class="nav-menu cf">
            <li>
                <a href="demos/playground">Try Flocking</a>
            </li>
-          <li>
-              <a href="https://github.com/colinbdclark/Flocking/releases/tag/0.1.2">Download v0.1.2</a>
-          </li>
            <li>
                <a href="http://github.com/colinbdclark/flocking">Source Code</a>
            </li>
            <li>
                 <a href="https://github.com/colinbdclark/Flocking/blob/master/README.md">Documentation</a>
            </li>
+           <li>
+                <a href="https://lists.idrc.ocadu.ca/mailman/listinfo/flocking">Join the Community List</a>
+            </li>
         </ul>
     </body>
 </html>


### PR DESCRIPTION
This PR updates references to Flocking from 0.1.2 to 1.0.0. Also ensures that third-party requests use HTTPS now that flockingjs.org does too!