### PR TITLE
nodejs: s/new Buffer\(/Buffer.alloc\(

### DIFF
--- a/src/nodejs/audio-system.js
+++ b/src/nodejs/audio-system.js
@@ -54,7 +54,7 @@ flock.file.readFromPath = function (options) {
 
         fs.stat(fileURL, function (error, stats) {
             fs.open(fileURL, "r", function (error, fd) {
-                var buf = new Buffer(stats.size);
+                var buf = Buffer.alloc(stats.size);
 
                 fs.read(fd, buf, 0, buf.length, null, function () {
                     var type = flock.file.parseFileExtension(path);

--- a/src/nodejs/buffer-writer.js
+++ b/src/nodejs/buffer-writer.js
@@ -31,7 +31,7 @@ fluid.defaults("flock.nodejs.bufferWriter", {
 flock.nodejs.bufferWriter.saveBuffer = function (o) {
     var encoded = flock.audio.encode.wav(o.buffer);
 
-    fs.writeFile(o.path, new Buffer(encoded), function (err) {
+    fs.writeFile(o.path, Buffer.alloc(encoded), function (err) {
         if (err) {
             if (!o.error) {
                 flock.fail("There was an error while writing a buffer named " +

--- a/src/nodejs/output-manager.js
+++ b/src/nodejs/output-manager.js
@@ -125,7 +125,7 @@ flock.nodejs.outputManager.makeSampleWriter = function (that, buses, nodeList) {
             bytesPerSample = that.options.bytesPerSample,
             nodes = nodeList.nodes,
             krPeriods = numBytes / m.bytesPerBlock,
-            out = new Buffer(numBytes);
+            out = Buffer.alloc(numBytes);
 
         if (numBytes < m.bytesPerBlock) {
             return;


### PR DESCRIPTION
The `new Buffer()` pattern has been deprecated in Node.js for
security reasons. Buffer.alloc is backported as far back as 4.x,
which is currently EOL.

This gets rid of a pesky deprecation warning too 😇