### PR TITLE
Fixes gh-210: Adds namespaces to all listeners.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,6 +144,13 @@ module.exports = function(grunt) {
                     files.flockingBase
                 ),
                 dest: "dist/<%= pkg.name %>-base.js"
+            },
+
+            customInfusion: {
+                src: [].concat(
+                    files.infusion, files.infusionViews
+                ),
+                dest: "dist/infusion-for-flocking.js"
             }
         },
 

--- a/demos/midi/receive/midi-receive-demo.js
+++ b/demos/midi/receive/midi-receive-demo.js
@@ -29,7 +29,7 @@
                     },
 
                     listeners: {
-                        noteOn: {
+                        "noteOn.forwardToSynth": {
                             func: "{synth}.noteOn",
                             args: [
                                 "{arguments}.0.note",
@@ -40,7 +40,10 @@
                             ]
                         },
 
-                        noteOff: "{synth}.noteOff({arguments}.0.note)"
+                        "noteOff.forwardToSynth": {
+                            func: "{synth}.noteOff",
+                            args: ["{arguments}.0.note"]
+                        }
                     }
                 }
             },
@@ -51,9 +54,7 @@
         },
 
         listeners: {
-            onCreate: [
-                "{that}.enviro.start()"
-            ]
+            "onCreate.startEnviro": "{that}.enviro.start()"
         },
 
         selectors: {

--- a/demos/midi/send/send-midi-demo.js
+++ b/demos/midi/send/send-midi-demo.js
@@ -27,7 +27,10 @@
         },
 
         listeners: {
-            onCreate: "{that}.setContent({that}.model.content)"
+            "onCreate.setContentFromModel": {
+                func: "{that}.setContent",
+                args: ["{that}.model.content"]
+            }
         }
     });
 
@@ -122,21 +125,17 @@
         },
 
         listeners: {
-            onCreate: [
-                {
-                    "this": "{that}.dom.sendButton",
-                    method: "click",
-                    args: ["{that}.send"]
-                }
-            ],
+            "onCreate.bindSendButton": {
+                "this": "{that}.dom.sendButton",
+                method: "click",
+                args: ["{that}.send"]
+            },
 
-            onSend: [
-                {
-                    priority: "last",
-                    funcName: "flock.demo.midiSender.sendCommand",
-                    args:     ["{that}"]
-                }
-            ]
+            "onSend.sendMidiCommand": {
+                priority: "last",
+                funcName: "flock.demo.midiSender.sendCommand",
+                args: ["{that}"]
+            }
         },
 
         selectors: {

--- a/demos/midi/sendRaw/sendRaw-midi-demo.js
+++ b/demos/midi/sendRaw/sendRaw-midi-demo.js
@@ -27,7 +27,10 @@
         },
 
         listeners: {
-            onCreate: "{that}.setContent({that}.model.content)"
+            "onCreate.setContentFromModel": {
+                func: "{that}.setContent",
+                args: ["{that}.model.content"]
+            }
         }
     });
 
@@ -156,25 +159,22 @@
         },
 
         listeners: {
-            onCreate: [
-                {
-                    "this": "{that}.dom.sendButton",
-                    method: "click",
-                    args: ["{that}.send"]
-                }
-            ],
+            "onCreate.bindSendButton": {
+                "this": "{that}.dom.sendButton",
+                method: "click",
+                args: ["{that}.send"]
+            },
 
-            onSend: [
-                {
-                    priority: "first",
-                    func: "{midiInputView}.updateContent"
-                },
-                {
-                    priority: "last",
-                    funcName: "flock.demo.rawMidiSender.enqueueMidiCommands",
-                    args: ["{that}.model.commandScore", "{that}"]
-                }
-            ]
+            "onSend.updateContent": {
+                priority: "first",
+                func: "{midiInputView}.updateContent"
+            },
+
+            "onSend.sendMidiCommands": {
+                priority: "last",
+                funcName: "flock.demo.rawMidiSender.enqueueMidiCommands",
+                args: ["{that}.model.commandScore", "{that}"]
+            }
         },
 
         selectors: {

--- a/demos/nodejs/midi.js
+++ b/demos/nodejs/midi.js
@@ -79,22 +79,20 @@ fluid.defaults("flock.demo.nodejs.midiConnection", {
     },
 
     listeners: {
-        onError: {
+        "onError.logToConsole": {
             "this": "console",
             method: "log"
         },
 
-        message: {
+        "message.logToConsole": {
             "this": "console",
             method: "log"
         },
 
-        control: [
-            {
-                changePath: "controlValue",
-                value: "{arguments}.0.value"
-            }
-        ]
+        "control.updateModel": {
+            changePath: "controlValue",
+            value: "{arguments}.0.value"
+        }
     }
 });
 

--- a/demos/playground/js/demo-selector.js
+++ b/demos/playground/js/demo-selector.js
@@ -59,31 +59,31 @@ var fluid = fluid || require("infusion"),
         },
 
         events: {
-            onSelect: "{selectBox}.events.onSelect",    // Fires when the user selects a demo.
+            onSelect: "{selectBox}.events.onSelect", // Fires when the user selects a demo.
             onURLHashChange: null,
             afterDemoLoaded: null
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.bindHashChangeListener": {
                 funcName: "flock.playground.demoSelector.listenForHashChanges",
                 args: ["{that}.events.onURLHashChange.fire"]
             },
 
-            onURLHashChange: {
+            "onURLHashChange.loadDemo": {
                 func: "{that}.loadDemoFromURL"
             },
 
-            onSelect: [
-                {
-                    funcName: "{that}.updateURL",
-                    args: ["{arguments}.0"]
-                },
-                {
+            "onSelect.updateURL": {
+                funcName: "{that}.updateURL",
+                args: ["{arguments}.0"]
+            },
+
+            "onSelect.loadDemo": {
+                    priority: "after:updateURL",
                     funcName: "{that}.loadDemo",
                     args: ["{arguments}.0"]
                 }
-            ]
         }
     });
 

--- a/demos/playground/js/playground.js
+++ b/demos/playground/js/playground.js
@@ -84,11 +84,14 @@ var fluid = fluid || require("infusion"),
                     },
 
                     listeners: {
-                        afterDemoLoaded: "{editor}.setContent({arguments}.0)",
+                        "afterDemoLoaded.setEditorContent": {
+                            func: "{editor}.setContent",
+                            args: ["{arguments}.0"],
+                        },
 
-                        onSelect: [
-                            "{playButton}.pause()"
-                        ]
+                        "onSelect.pause": {
+                            func: "{playButton}.pause"
+                        }
                     }
                 }
             },
@@ -110,13 +113,9 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "{demoSelector}.loadDemoFromURL()"
-            ],
+            "onCreate.loadDemo": "{demoSelector}.loadDemoFromURL()",
 
-            onError: [
-                "flock.fail({arguments}.0)"
-            ]
+            "onError.fail": "flock.fail({arguments}.0)"
         },
 
         selectors: {
@@ -136,10 +135,12 @@ var fluid = fluid || require("infusion"),
         gradeNames: ["flock.playground"],
 
         listeners: {
-            onEvaluateDemo: [
-                "{that}.parse()",
-                "{evaluator}.evaluate()"
-            ]
+            "onEvaluateDemo.parse": "{that}.parse()",
+
+            "onEvaluateDemo.evaluate": {
+                priority: "after:parse",
+                func: "{evaluator}.evaluate"
+            }
         }
     });
 }());

--- a/demos/playground/live/js/visual-editor.js
+++ b/demos/playground/live/js/visual-editor.js
@@ -38,13 +38,11 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                {
-                    "this": "{that}.plumb",
-                    method: "ready",
-                    args: "{that}.events.onReady.fire"
-                }
-            ]
+            "onCreate.bindJSPlumbReady": {
+                "this": "{that}.plumb",
+                method: "ready",
+                args: "{that}.events.onReady.fire"
+            }
         }
     });
 
@@ -132,13 +130,9 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onSourceUpdated: [
-                "{that}.parse()"
-            ],
+            "onSourceUpdated.parse": "{that}.parse()",
 
-            onEvaluateDemo: [
-                "{evaluator}.evaluate()"
-            ]
+            "onEvaluateDemo.evaluate": "{evaluator}.evaluate()"
         }
     });
 
@@ -216,10 +210,14 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onRender: [
-                "{that}.prepareRenderModel()",
-                "{that}.render()"
-            ]
+            "onRender.prepareRenderModel": {
+                func: "{that}.prepareRenderModel"
+            },
+
+            "onRender.render": {
+                priority: "after:prepareRenderModel",
+                func: "{that}.render"
+            }
         },
 
         markup: {
@@ -417,7 +415,7 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.refreshView": {
                 func: "{that}.refreshView"
             }
         },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,7 +81,7 @@ Here is an example of an HTML page that uses Flocking, which you can use as a te
         // which is one of the built-in lifecycle events for Infusion.
         // When onCreate fires, we start the Flocking environment.
         listeners: {
-            "onCreate.startEnvironment: {
+            "onCreate.startEnvironment": {
                 func: "{environment}.start"
             }
         }

--- a/docs/responding-to-user-input.md
+++ b/docs/responding-to-user-input.md
@@ -245,22 +245,21 @@ JavScript:
             listeners: {
                 // Listen for the event that fires when this component has been fully
                 // instantiated.
-                onCreate: [
-                    // The first time the user clicks, start the Flocking environment.
-                    {
-                        "this": "{that}.container",
-                        method: "one",
-                        args: ["click", "{synth}.play"]
-                    },
 
+                "onCreate.playSynth": {
+                    // The first time the user clicks, start the Flocking environment.
+                    "this": "{that}.container",
+                    method: "one",
+                    args: ["click", "{synth}.play"]
+                },
+
+                "onCreate.bindClickHandler": {
                     // Bind a click handler to our container
                     // that will invoke the "fireRandomLine" method.
-                    {
-                        "this": "{that}.container",
-                        method: "click",
-                        args: "{that}.handleClick"
-                    }
-                ]
+                    "this": "{that}.container",
+                    method: "click",
+                    args: "{that}.handleClick"
+                }
             }
         });
 

--- a/src/buffers.js
+++ b/src/buffers.js
@@ -245,7 +245,7 @@ var fluid = fluid || require("infusion"),
                 type: "flock.promise",
                 options: {
                     listeners: {
-                        onCreate: {
+                        "onCreate.bindPromiseEvents": {
                             "this": "{that}.promise",
                             method: "then",
                             args: ["{bufferSource}.events.afterFetch.fire", "{bufferSource}.events.onError.fire"]
@@ -273,34 +273,37 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.fireRefresh": {
                 funcName: "{that}.events.onRefreshPromise.fire"
             },
 
-            onRefreshPromise: {
+            "onRefreshPromise.updateState": {
                 changePath: "state",
                 value: "start"
             },
 
-            onFetch: {
+            "onFetch.updateState": {
                 changePath: "state",
                 value: "in-progress"
             },
 
-            afterFetch: [
-                {
-                    changePath: "state",
-                    value: "fetched"
-                },
-                {
-                    funcName: "{that}.events.onBufferUpdated.fire", // TODO: Replace with boiling?
-                    args: ["{arguments}.0"]
-                }
-            ],
+            "afterFetch.updateState": {
+                changePath: "state",
+                value: "fetched"
+            },
 
-            onBufferUpdated: "{enviro}.registerBuffer({arguments}.0)",
+            "afterFetch.fireBufferUpdated": {
+                priority: "after:updateState",
+                funcName: "{that}.events.onBufferUpdated.fire", // TODO: Replace with boiling?
+                args: ["{arguments}.0"]
+            },
 
-            onError: {
+            "onBufferUpdated.registerBuffer": {
+                func: "{enviro}.registerBuffer",
+                args: ["{arguments}.0"],
+            },
+
+            "onError.updateState": {
                 changePath: "state",
                 value: "error"
             }

--- a/src/core.js
+++ b/src/core.js
@@ -1279,25 +1279,44 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "flock.enviro.registerGlobalSingleton({that})"
-            ],
+            "onCreate.registerSingleton": {
+                funcName: "flock.enviro.registerGlobalSingleton",
+                args: ["{that}"]
+            },
 
-            onStart: [
-                "{that}.applier.change(isPlaying, true)",
-            ],
+            "onStart.updatePlayState": {
+                changePath: "isPlaying",
+                value: true
+            },
 
-            onStop: [
-                "{that}.applier.change(isPlaying, false)"
-            ],
+            "onStop.updatePlayState": {
+                changePath: "isPlaying",
+                value: false
+            },
 
-            onReset: [
-                "{that}.stop()",
-                "{asyncScheduler}.clearAll()",
-                "flock.nodeList.clearAll({that}.nodeList)",
-                "{busManager}.reset()",
-                "fluid.clear({that}.buffers)"
-            ]
+            "onReset.stop": "{that}.stop()",
+
+            "onReset.clearScheduler": {
+                priority: "after:stop",
+                func: "{asyncScheduler}.clearAll"
+            },
+
+            "onReset.clearAllNodes": {
+                priority: "after:clearScheduler",
+                func: "flock.nodeList.clearAll",
+                args: ["{that}.nodeList"]
+            },
+
+            "onReset.resetBusManager": {
+                priority: "after:clearAllNodes",
+                func: "{busManager}.reset"
+            },
+
+            "onReset.clearBuffers": {
+                priority: "after:resetBusManager",
+                funcName: "fluid.clear",
+                args: ["{that}.buffers"]
+            }
         }
     });
 
@@ -1397,9 +1416,10 @@ var fluid = fluid || require("infusion"),
         gradeNames: "flock.enviro",
 
         listeners: {
-            onCreate: [
-                "flock.silentEnviro.insertOutputGainNode({that})"
-            ]
+            "onCreate.insertGainNode": {
+                funcName: "flock.silentEnviro.insertOutputGainNode",
+                args: "{that}"
+            }
         }
     });
 
@@ -1485,13 +1505,14 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "{that}.addToEnvironment({that}.options.addToEnvironment)"
-            ],
+            "onCreate.addToEnvironment": {
+                func: "{that}.addToEnvironment",
+                args: ["{that}.options.addToEnvironment"]
+            },
 
-            onDestroy: [
-                "{that}.removeFromEnvironment()"
-            ]
+            "onDestroy.removeFromEnvironment": {
+                func: "{that}.removeFromEnvironment"
+            }
         }
     });
 

--- a/src/midi/controller.js
+++ b/src/midi/controller.js
@@ -82,10 +82,10 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            control: "{that}.mapControl({arguments}.0)",
-            note: "{that}.mapNote(note, {arguments}.0)",
-            noteOn: "{that}.mapNote(noteOn, {arguments}.0)",
-            noteOff: "{that}.mapNote(noteOff, {arguments}.0)"
+            "control.map": "{that}.mapControl({arguments}.0)",
+            "note.map": "{that}.mapNote(note, {arguments}.0)",
+            "noteOn.map": "{that}.mapNote(noteOn, {arguments}.0)",
+            "noteOff.map": "{that}.mapNote(noteOff, {arguments}.0)"
         }
     });
 

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -230,7 +230,7 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.initClock": {
                 funcName: "flock.scheduler.webWorkerClock.init",
                 args: ["{that}"]
             },
@@ -497,13 +497,21 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onScheduled: [
-                "{that}.addIntervalListener({arguments}.0, {arguments}.1)",
-                "{that}.clock.schedule({arguments}.0)"
-            ],
-            onFinished: [
-                "{that}.removeIntervalListener({arguments}.0, {arguments}.1)"
-            ]
+            "onScheduled.addIntervalListener": {
+                func: "{that}.addIntervalListener",
+                args: ["{arguments}.0", "{arguments}.1"]
+            },
+
+            "onScheduled.scheduleEvent": {
+                priority: "after:addIntervalListener",
+                func: "{that}.clock.schedule",
+                args: ["{arguments}.0"]
+            },
+
+            "onFinished.removeIntervalListener": {
+                func: "{that}.removeIntervalListener",
+                args: ["{arguments}.0", "{arguments}.1"]
+            }
         }
     });
 
@@ -613,21 +621,21 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onScheduled: [
-                {
-                    funcName: "flock.scheduler.addListener",
-                    args: [
-                        "{arguments}.1", // The listener.
-                        "{that}.listeners", // All registered listeners.
-                        "{that}.clock.events.tick.addListener"
-                    ]
-                },
-                {
-                    func: "{that}.clock.schedule",
-                    args: ["{arguments}.0"]
-                }
-            ],
-            onFinished: {
+            "onScheduled.addListener": {
+                funcName: "flock.scheduler.addListener",
+                args: [
+                    "{arguments}.1", // The listener.
+                    "{that}.listeners", // All registered listeners.
+                    "{that}.clock.events.tick.addListener"
+                ]
+            },
+
+            "onScheduled.scheduleEvent": {
+                func: "{that}.clock.schedule",
+                args: ["{arguments}.0"]
+            },
+
+            "onFinished.removeListener": {
                 funcName: "flock.scheduler.removeListener",
                 args: [
                     "{arguments}.0",    // The listener.
@@ -790,8 +798,8 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: "{that}.schedule({that}.options.score)",
-            onEnd: "{that}.clearAll"
+            "onCreate.scheduleScore": "{that}.schedule({that}.options.score)",
+            "onEnd.clearAllEvents": "{that}.clearAll"
         }
     });
 

--- a/src/synths/group.js
+++ b/src/synths/group.js
@@ -59,36 +59,38 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onInsert: [
-                {
-                    funcName: "flock.synth.group.bindMethods",
-                    args: [
-                        "{arguments}.0", // The newly added node.
-                        "{that}.options.methodEventMap",
-                        "{that}.events",
-                        "addListener"
-                    ]
-                },
+            "onInsert.bindMethods": {
+                funcName: "flock.synth.group.bindMethods",
+                args: [
+                    "{arguments}.0", // The newly added node.
+                    "{that}.options.methodEventMap",
+                    "{that}.events",
+                    "addListener"
+                ]
+            },
 
-                "flock.synth.group.removeNodeFromEnvironment({arguments}.0)"
-            ],
+            "onInsert.removeNode": {
+                priority: "after:bindMethods",
+                funcName: "flock.synth.group.removeNodeFromEnvironment",
+                args: ["{arguments}.0"]
+            },
 
-            onRemove: [
-                {
-                    funcName: "flock.synth.group.bindMethods",
-                    args: [
-                        "{arguments}.0", // The removed node.
-                        "{that}.options.methodEventMap",
-                        "{that}.events",
-                        "removeListener"
-                    ]
-                },
-                {
-                    "this": "{that}.nodeList",
-                    method: "remove",
-                    args: ["{arguments}.0"]
-                }
-            ]
+            "onRemove.bindMethods": {
+                funcName: "flock.synth.group.bindMethods",
+                args: [
+                    "{arguments}.0", // The removed node.
+                    "{that}.options.methodEventMap",
+                    "{that}.events",
+                    "removeListener"
+                ]
+            },
+
+            "onRemove.removeNode": {
+                priority: "after:bindMethods",
+                "this": "{that}.nodeList",
+                method: "remove",
+                args: ["{arguments}.0"]
+            }
         }
     });
 

--- a/src/synths/polyphonic.js
+++ b/src/synths/polyphonic.js
@@ -46,7 +46,7 @@ var fluid = fluid || require("infusion"),
             amplitudeKey: "{polyphonic}.options.amplitudeKey",
 
             listeners: {
-                onCreateVoice: {
+                "onCreateVoice.addVoiceToTail": {
                     funcName: "flock.nodeList.tail",
                     args: ["{polyphonic}.nodeList", "{arguments}.0"]
                 }

--- a/src/ui/editor/js/editor.js
+++ b/src/ui/editor/js/editor.js
@@ -65,7 +65,7 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onValidatedContentChange: {
+            "onValidatedContentChange.throttleContentValidation": {
                 funcName: "flock.ui.codeMirror.throttleContentValidation",
                 args: [
                     "{arguments}.1", // Is valid?

--- a/src/ui/midi/message-view/js/message-view.js
+++ b/src/ui/midi/message-view/js/message-view.js
@@ -33,7 +33,7 @@ var fluid = fluid || require("infusion");
             target: "{/ flock.midi.connection}.options",
             record: {
                 listeners: {
-                    message: {
+                    "message.logMIDI": {
                         func: "flock.ui.midiMessageView.logMIDI",
                         args: [
                             "{midiMessageView}",

--- a/src/ui/midi/midi-connector/js/midi-connector.js
+++ b/src/ui/midi/midi-connector/js/midi-connector.js
@@ -60,9 +60,9 @@ var fluid = fluid || require("infusion");
                     },
 
                     listeners: {
-                        onCreate: [
-                            "{midiConnector}.events.afterConnectionOpen.fire()"
-                        ]
+                        "onCreate.fireAfterConnectionOpen": {
+                            func: "{midiConnector}.events.afterConnectionOpen.fire"
+                        }
                     }
                 }
             }

--- a/src/ui/midi/midi-port-selector/js/midi-port-selector.js
+++ b/src/ui/midi/midi-port-selector/js/midi-port-selector.js
@@ -70,56 +70,56 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "{that}.refreshView()"
-            ],
+            "onCreate.refreshView": "{that}.refreshView()",
 
             // TODO: Move the selectBox portions of this to the selectBox component.
-            onRender: [
-                {
-                    funcName: "flock.ui.midiPortSelector.render",
-                    args: [
-                        "{that}.container",
-                        "{that}.options.markup.label",
-                        "{that}.options.selectBoxStrings"
-                    ]
-                },
-                {
-                    funcName: "flock.ui.midiPortSelector.render",
-                    args: [
-                        "{that}.container",
-                        "{that}.options.markup.selectBox",
-                        "{that}.options.selectBoxStrings"
-                    ]
-                },
-                {
-                    funcName: "flock.ui.midiPortSelector.renderRefreshButton",
-                    args: [
-                        "{that}.container",
-                        "{that}.options.markup.refreshButton",
-                        "{that}.options.strings",
-                        "{that}.events.onRefresh.fire"
-                    ]
-                },
-                {
-                    func: "{that}.events.afterRender.fire"
-                }
-            ],
+            "onRender.renderLabel": {
+                funcName: "flock.ui.midiPortSelector.render",
+                args: [
+                    "{that}.container",
+                    "{that}.options.markup.label",
+                    "{that}.options.selectBoxStrings"
+                ]
+            },
 
-            onRefresh: [
-                "{midiSystem}.refreshPorts()"
-            ],
+            "onRender.renderSelectBox": {
+                priority: "after:renderLabel",
+                funcName: "flock.ui.midiPortSelector.render",
+                args: [
+                    "{that}.container",
+                    "{that}.options.markup.selectBox",
+                    "{that}.options.selectBoxStrings"
+                ]
+            },
 
-            onPortsAvailable: [
-                {
-                    changePath: "ports",
-                    type: "DELETE"
-                },
-                {
-                    funcName: "flock.ui.midiPortSelector.updatePortsModel",
-                    args: ["{that}.options.portType", "{arguments}.0", "{that}"]
-                }
-            ]
+            "onRender.renderRefreshButton": {
+                priority: "after:renderSelectBox",
+                funcName: "flock.ui.midiPortSelector.renderRefreshButton",
+                args: [
+                    "{that}.container",
+                    "{that}.options.markup.refreshButton",
+                    "{that}.options.strings",
+                    "{that}.events.onRefresh.fire"
+                ]
+            },
+
+            "onRender.fireAfterRender": {
+                priority: "last",
+                func: "{that}.events.afterRender.fire"
+            },
+
+            "onRefresh.refreshSystemPorts": "{midiSystem}.refreshPorts()",
+
+            "onPortsAvailable.deleteOldPorts": {
+                changePath: "ports",
+                type: "DELETE"
+            },
+
+            "onPortsAvailable.updatePortsModel": {
+                priority: "after:deleteOldPorts",
+                funcName: "flock.ui.midiPortSelector.updatePortsModel",
+                args: ["{that}.options.portType", "{arguments}.0", "{that}"]
+            }
         },
 
         markup: {

--- a/src/ui/play-button/js/play-button.js
+++ b/src/ui/play-button/js/play-button.js
@@ -65,54 +65,53 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                {
-                    funcName: "flock.ui.toggleButton.render",
-                    args: ["{that}"]
-                },
+            "onCreate.renderToggleButton": {
+                funcName: "flock.ui.toggleButton.render",
+                args: ["{that}"]
+            },
 
-                {
-                    "this": "{that}.container",
-                    method: "click",
-                    args: "{that}.toggle"
-                }
-            ],
+            "onCreate.bindToggleButtonClick": {
+                priority: "after:renderToggleButton",
+                "this": "{that}.container",
+                method: "click",
+                args: "{that}.toggle"
+            },
 
-            on: [
-                {
-                    "this": "{that}.container",
-                    method: "addClass",
-                    args: ["{that}.options.styles.on"]
-                },
-                {
-                    "this": "{that}.container",
-                    method: "removeClass",
-                    args: ["{that}.options.styles.off"]
-                },
-                {
-                    "this": "{that}.container",
-                    method: "html",
-                    args: "{that}.options.strings.on"
-                }
-            ],
+            "on.addEnabledStyling": {
+                "this": "{that}.container",
+                method: "addClass",
+                args: ["{that}.options.styles.on"]
+            },
 
-            off: [
-                {
-                    "this": "{that}.container",
-                    method: "addClass",
-                    args: ["{that}.options.styles.off"]
-                },
-                {
-                    "this": "{that}.container",
-                    method: "removeClass",
-                    args: ["{that}.options.styles.on"]
-                },
-                {
-                    "this": "{that}.container",
-                    method: "html",
-                    args: "{that}.options.strings.off"
-                }
-            ]
+            "on.removeDisabledStyling": {
+                "this": "{that}.container",
+                method: "removeClass",
+                args: ["{that}.options.styles.off"]
+            },
+
+            "on.updateLabel": {
+                "this": "{that}.container",
+                method: "html",
+                args: "{that}.options.strings.on"
+            },
+
+            "off.addDisabledStyle": {
+                "this": "{that}.container",
+                method: "addClass",
+                args: ["{that}.options.styles.off"]
+            },
+
+            "off.removeEnabledStyle": {
+                "this": "{that}.container",
+                method: "removeClass",
+                args: ["{that}.options.styles.on"]
+            },
+
+            "off.updateLabel": {
+                "this": "{that}.container",
+                method: "html",
+                args: "{that}.options.strings.off"
+            }
         },
 
         modelListeners: {
@@ -208,18 +207,18 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                {
-                    "this": "{that}.container",
-                    method: "addClass",
-                    args: "{that}.options.styles.playButton"
-                },
-                {
-                    "this": "{that}.container",
-                    method: "addClass",
-                    args: "{that}.options.styles.iconFont"
-                }
-            ]
+            "onCreate.addButtonStyle": {
+                "this": "{that}.container",
+                method: "addClass",
+                args: "{that}.options.styles.playButton"
+            },
+
+            "onCreate.addIconFontStyle": {
+                priority: "after:addButtonStyle",
+                "this": "{that}.container",
+                method: "addClass",
+                args: "{that}.options.styles.iconFont"
+            }
         },
 
         strings: {
@@ -267,32 +266,38 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onFadeIn: [
-                "{that}.enviro.start()",
-                "{fader}.fadeIn(1.0)"
-            ],
+            "onFadeIn.startEnviro": "{that}.enviro.start()",
 
-            onFadeOut: [
-                "{fader}.fadeTo(0.0)",
-                "flock.ui.enviroPlayButton.disableForFadeOut({that}.model, {that}.applier)",
-                {
-                    funcName: "flock.ui.enviroPlayButton.renableAfterFadeOutDelay",
-                    args: [
-                        "{that}.enviro",
-                        "{that}.model",
-                        "{that}.applier",
-                        "{that}.resetTime",
-                        "{that}.events.afterFadeOut.fire"
-                    ]
-                }
-            ],
+            "onFadeIn.fadeIn": {
+                priority: "after:startEnviro",
+                func: "{fader}.fadeIn",
+                args: [1.0]
+            },
 
-            afterFadeOut: [
-                {
-                    func: "{that}.enviro.stop",
-                    namespace: "stopEnviro"
-                }
-            ]
+            "onFadeOut.fadeOut": "{fader}.fadeTo(0.0)",
+
+            "onFadeOut.disableButton": {
+                priority: "after:fadeOut",
+                funcName: "flock.ui.enviroPlayButton.disableForFadeOut",
+                args: ["{that}.model", "{that}.applier"]
+            },
+
+            "onFadeOut.renableAfterFade": {
+                priority: "after:disableButton",
+                funcName: "flock.ui.enviroPlayButton.renableAfterFadeOutDelay",
+                args: [
+                    "{that}.enviro",
+                    "{that}.model",
+                    "{that}.applier",
+                    "{that}.resetTime",
+                    "{that}.events.afterFadeOut.fire"
+                ]
+            },
+
+            "afterFadeOut.stopEnviro": {
+                func: "{that}.enviro.stop",
+                namespace: "stopEnviro"
+            }
         },
 
         modelListeners: {
@@ -346,12 +351,10 @@ var fluid = fluid || require("infusion"),
         gradeNames: ["flock.ui.enviroPlayButton"],
 
         listeners: {
-            afterFadeOut: [
-                {
-                    func: "{that}.enviro.reset",
-                    priority: "after:stopEnviro"
-                }
-            ]
+            "afterFadeOut.resetEnviro": {
+                func: "{that}.enviro.reset",
+                priority: "after:stopEnviro"
+            }
         }
     });
 

--- a/src/ui/selectbox/js/selectbox.js
+++ b/src/ui/selectbox/js/selectbox.js
@@ -90,46 +90,51 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                {
-                    "this": "{that}.container",
-                    method: "change",
-                    args: ["{that}.handleChange"]
-                },
-                {
-                    funcName: "{that}.events.onRender.fire"
-                }
-            ],
+            "onCreate.bindChangeHandler": {
+                "this": "{that}.container",
+                method: "change",
+                args: ["{that}.handleChange"]
+            },
+            "onCreate.fireOnRender": {
+                priority: "after:bindChangeHandler",
+                func: "{that}.events.onRender.fire"
+            },
 
-            onRender: [
-                {
-                    funcName: "flock.ui.selectBox.clearContainer",
-                    args: "{that}.container"
-                },
-                {
-                    funcName: "flock.ui.selectBox.renderGroups",
-                    args: [
-                        "{that}.container",
-                        "{that}.model.groups",
-                        "{that}.options.markup"
-                    ]
-                },
-                {
-                    funcName: "flock.ui.selectBox.renderOptions",
-                    args: [
-                        "{that}.container",
-                        "{that}.model.options",
-                        "{that}.options.markup"
-                    ]
-                },
-                {
-                    funcName: "flock.ui.selectBox.selectInitial",
-                    args: "{that}"
-                },
-                {
-                    func: "{that}.events.afterRender.fire"
-                }
-            ]
+            "onRender.clearContainer": {
+                funcName: "flock.ui.selectBox.clearContainer",
+                args: "{that}.container"
+            },
+
+            "onRender.renderGroups": {
+                priority: "after:clearContainer",
+                funcName: "flock.ui.selectBox.renderGroups",
+                args: [
+                    "{that}.container",
+                    "{that}.model.groups",
+                    "{that}.options.markup"
+                ]
+            },
+
+            "onRender.renderOptions": {
+                priority: "after:renderGroups",
+                funcName: "flock.ui.selectBox.renderOptions",
+                args: [
+                    "{that}.container",
+                    "{that}.model.options",
+                    "{that}.options.markup"
+                ]
+            },
+
+            "onRender.selectInitial": {
+                priority: "after:renderOptions",
+                funcName: "flock.ui.selectBox.selectInitial",
+                args: "{that}"
+            },
+
+            "onRender.fireAfterRender": {
+                priority: "last",
+                func: "{that}.events.afterRender.fire"
+            }
         }
     });
 

--- a/src/web/audio-system.js
+++ b/src/web/audio-system.js
@@ -58,9 +58,10 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "flock.webAudio.audioSystem.configureDestination({that}.context, {that}.model.chans)"
-            ]
+            "onCreate.configureDestination": {
+                funcName: "flock.webAudio.audioSystem.configureDestination",
+                args: ["{that}.context", "{that}.model.chans"]
+            }
         }
     });
 

--- a/src/web/midi.js
+++ b/src/web/midi.js
@@ -372,17 +372,27 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.requestAccess": {
                 func: "{that}.requestAccess"
             },
 
-            onAccessGranted: [
-                "flock.midi.system.setAccess({that}, {arguments}.0)",
-                "{that}.refreshPorts()",
-                "{that}.events.onReady.fire({that}.ports)"
-            ],
+            "onAccessGranted.setAccess": {
+                func: "flock.midi.system.setAccess",
+                args: ["{that}", "{arguments}.0"]
+            },
 
-            onAccessError: {
+            "onAccessGranted.refreshPorts": {
+                priority: "after:setAccess",
+                func: "{that}.refreshPorts"
+            },
+
+            "onAccessGranted.fireOnReady": {
+                priority: "after:refreshPorts",
+                func: "{that}.events.onReady.fire",
+                args: ["{that}.ports)"]
+            },
+
+            "onAccessError.logError": {
                 funcName: "fluid.log",
                 args: [fluid.logLevel.WARN, "MIDI Access Error: ", "{arguments}.0"]
             }
@@ -506,26 +516,24 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onPortsAvailable: {
+            "onPortsAvailable.open": {
                 funcName: "flock.midi.connection.autoOpen",
                 args: [
                     "{that}.options.openImmediately", "{that}.open"
                 ]
             },
 
-            onError: {
+            "onError.logError": {
                 funcName: "fluid.log",
                 args: [fluid.logLevel.WARN, "{arguments}.0"]
             },
 
-            raw: {
+            "raw.fireMidiEvent": {
                 funcName: "flock.midi.connection.fireEvent",
                 args: ["{arguments}.0", "{that}.events"]
             },
 
-            onDestroy: [
-                "{that}.close()"
-            ]
+            "onDestroy.close": "{that}.close()"
         }
     });
 

--- a/src/web/native-node-manager.js
+++ b/src/web/native-node-manager.js
@@ -154,71 +154,86 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                "{that}.events.onCreateScriptProcessor.fire()",
-                {
-                    func: "{that}.insertOutput",
-                    args: "{scriptProcessor}.node"
-                }
-            ],
-
-            onStart: [
-                "{that}.connect()"
-            ],
-
-            onConnect: [
-                {
-                    "this": "{merger}.node",
-                    method: "connect",
-                    args: ["{scriptProcessor}.node"]
-                },
-                {
-                    "this": "{that}.outputNode",
-                    method: "connect",
-                    args: ["{audioSystem}.context.destination"]
-                },
-                {
-                    funcName: "flock.webAudio.nativeNodeManager.connectOutput",
-                    args: ["{scriptProcessor}.node", "{that}.outputNode"]
-                }
-            ],
-
-            onStop: [
-                "{that}.disconnect()"
-            ],
-
-            onDisconnectNodes: [
-                {
-                    "this": "{merger}.node",
-                    method: "disconnect",
-                    args: [0]
-                },
-                {
-                    "this": "{scriptProcessor}.node",
-                    method: "disconnect",
-                    args: [0]
-                },
-                {
-                    "this": "{that}.outputNode",
-                    method: "disconnect",
-                    args: [0]
-                }
-            ],
-
-            "onDisconnect.onDisconnectNodes": {
-                 func: "{that}.events.onDisconnectNodes.fire",
+            "onCreate.fireOnCreateScriptProcessor": {
+                func:"{that}.events.onCreateScriptProcessor.fire"
             },
 
-            onReset: [
-                "{that}.removeAllInputs()",
-                "{that}.events.onCreateScriptProcessor.fire()"
-            ],
+            "onCreate.insertOutputNode": {
+                priority: "after:fireOnCreateScriptProcessor",
+                func: "{that}.insertOutput",
+                args: "{scriptProcessor}.node"
+            },
 
-            onDestroy: [
-                "{that}.events.onDisconnectNodes.fire()",
-                "{that}.removeAllInputs()",
-                "flock.webAudio.nativeNodeManager.disconnectOutput({that})"
-            ]
+            "onStart.connect": "{that}.connect()",
+
+            "onConnect.connectMergerNode": {
+                "this": "{merger}.node",
+                method: "connect",
+                args: ["{scriptProcessor}.node"]
+            },
+
+            "onConnect.connectOutputNode": {
+                priority: "after:connectMergerNode",
+                "this": "{that}.outputNode",
+                method: "connect",
+                args: ["{audioSystem}.context.destination"]
+            },
+
+            "onConnect.connectOutput": {
+                priority: "after:connectOutputNode",
+                funcName: "flock.webAudio.nativeNodeManager.connectOutput",
+                args: ["{scriptProcessor}.node", "{that}.outputNode"]
+            },
+
+            "onStop.disconnect": "{that}.disconnect()",
+
+
+            "onDisconnect.fireOnDisconnectNodes": {
+                func: "{that}.events.onDisconnectNodes.fire",
+            },
+
+            "onDisconnectNodes.disconnectMergerNode": {
+                "this": "{merger}.node",
+                method: "disconnect",
+                args: [0]
+            },
+
+            "onDisconnect.disconnectScriptProcessorNode": {
+                priority: "after:disconnectMergerNode",
+                "this": "{scriptProcessor}.node",
+                method: "disconnect",
+                args: [0]
+            },
+
+            "onDisconnectNodes.disconnectOuptutNode": {
+                priority: "after:disconnectScriptProcessorNode",
+                "this": "{that}.outputNode",
+                method: "disconnect",
+                args: [0]
+            },
+
+            "onReset.removeAllInputs": {
+                func: "{that}.removeAllInputs"
+            },
+
+            "onReset.fireOnCreateScriptProcessor": {
+                func: "{that}.events.onCreateScriptProcessor.fire"
+            },
+
+            "onDestroy.fireOnDisconnectNodes": {
+                func: "{that}.events.onDisconnectNodes.fire"
+            },
+
+            "onDestroy.removeAllInputs": {
+                priority: "after:fireOnDisconnectNodes",
+                func: "{that}.removeAllInputs"
+            },
+
+            "onDestroy.disconnectOutput": {
+                priority: "after:removeAllInputs",
+                func: "flock.webAudio.nativeNodeManager.disconnectOutput",
+                args: ["{that}"]
+            }
         }
     });
 

--- a/tests/unit/html/band-tests.html
+++ b/tests/unit/html/band-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/buffer-ugen-tests.html
+++ b/tests/unit/html/buffer-ugen-tests.html
@@ -7,10 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
-
+        <script src="../../../dist/infusion-for-flocking.js"></script>
         <script src="../../../third-party/webarraymath/js/webarraymath.js"></script>
 
         <script src="../../../src/core.js"></script>

--- a/tests/unit/html/bus-tests.html
+++ b/tests/unit/html/bus-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/playbuffer-ugen-tests.html
+++ b/tests/unit/html/playbuffer-ugen-tests.html
@@ -7,9 +7,8 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
+
 
         <script src="../../../third-party/webarraymath/js/webarraymath.js"></script>
 

--- a/tests/unit/html/synth-environment-tests.html
+++ b/tests/unit/html/synth-environment-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-evaluation-tests.html
+++ b/tests/unit/html/synth-evaluation-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-group-tests.html
+++ b/tests/unit/html/synth-group-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-instantiation-tests.html
+++ b/tests/unit/html/synth-instantiation-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-note-target-tests.html
+++ b/tests/unit/html/synth-note-target-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-removal-tests.html
+++ b/tests/unit/html/synth-removal-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-scheduled-tests.html
+++ b/tests/unit/html/synth-scheduled-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/synth-tests.html
+++ b/tests/unit/html/synth-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../src/core.js"></script>
         <script src="../../../src/node-list.js"></script>

--- a/tests/unit/html/writebuffer-ugen-tests.html
+++ b/tests/unit/html/writebuffer-ugen-tests.html
@@ -7,9 +7,7 @@
         <link rel="stylesheet" media="screen" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
 
         <script src="../../../node_modules/jquery/dist/jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/lib/jquery/ui/js/jquery-ui.js"></script>
-        <script src="../../../node_modules/infusion/dist/infusion-framework-no-jquery.js"></script>
-        <script src="../../../node_modules/infusion/src/framework/enhancement/js/ContextAwareness.js"></script>
+        <script src="../../../dist/infusion-for-flocking.js"></script>
 
         <script src="../../../third-party/webarraymath/js/webarraymath.js"></script>
 

--- a/tests/unit/js/buffer-ugen-tests.js
+++ b/tests/unit/js/buffer-ugen-tests.js
@@ -108,7 +108,7 @@ var fluid = fluid || require("infusion"),
                 }
             ],
             listeners: {
-                afterBuffersLoaded: function () {
+                "afterBuffersLoaded.runTest": function () {
                     flock.evaluate.synth(s);
                     flock.test.unbrokenAudioSignalInRange(chopper.output, -1, 1);
                     QUnit.start();

--- a/tests/unit/js/envelope-ugen-tests.js
+++ b/tests/unit/js/envelope-ugen-tests.js
@@ -36,7 +36,7 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.runTests": {
                 funcName: "flock.test.ugen.line.runTests",
                 args: "{that}"
             }
@@ -110,7 +110,7 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: {
+            "onCreate.runTests": {
                 funcName: "flock.test.ugen.asr.runTests",
                 args: "{that}"
             }

--- a/tests/unit/js/filter-ugen-tests.js
+++ b/tests/unit/js/filter-ugen-tests.js
@@ -23,7 +23,7 @@ var fluid = fluid || require("infusion"),
         name: "flock.ugen.delay",
 
         listeners: {
-            onCreate: {
+            "onCreate.runTests": {
                 funcName: "flock.test.ugen.delay.runTests",
                 args: "{that}"
             }
@@ -120,7 +120,7 @@ var fluid = fluid || require("infusion"),
         ],
 
         listeners: {
-            onCreate: {
+            "onCreate.runTests": {
                 funcName: "flock.test.ugen.filter.runTests",
                 args: "{that}"
             }


### PR DESCRIPTION
This PR adds namespaces to all event listeners on Flocking's Infusion-based components, removing undue sequentialism in the process. 

Also adds a custom build of Infusion to avoid errors related to jQuery UI not being present (because it's required by Infusion's keyboard-a11y plugin which is included in Infusion's framework-only build but not needed by Flocking).

