### PR TITLE
Fixes gh-265 and gh-266 and updates third party deps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-jshint": "2.0.0",
     "sheep-benchmark": "colinbdclark/sheep.js",
     "requirejs": "2.3.6",
-    "testem": "2.9.3"
+    "testem": "2.14.0"
   },
   "dependencies": {
     "jquery": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -22,23 +22,22 @@
   "browser": "dist/flocking-all.js",
   "devDependencies": {
     "grunt": "1.0.3",
-    "grunt-contrib-clean": "1.1.0",
+    "grunt-contrib-clean": "2.0.0",
     "grunt-contrib-concat": "1.0.1",
-    "grunt-contrib-uglify": "3.4.0",
+    "grunt-contrib-uglify": "4.0.0",
     "grunt-contrib-copy": "1.0.0",
-    "grunt-contrib-jshint": "1.1.0",
+    "grunt-contrib-jshint": "2.0.0",
     "sheep-benchmark": "colinbdclark/sheep.js",
-    "requirejs": "2.3.5",
+    "requirejs": "2.3.6",
     "testem": "2.9.3"
   },
   "dependencies": {
     "jquery": "3.3.1",
-    "infusion": "3.0.0-dev.20180924T230735Z.05b2dbfdc",
+    "infusion": "3.0.0-dev.20181204T213346Z.2ca90f6e6",
     "codemirror-infusion": "2.2.0",
     "jsplumb": "1.7.9",
-    "dagre": "0.8.2",
-    "normalize.css": "8.0.0",
-    "atob": "2.1.2"
+    "dagre": "0.8.4",
+    "normalize.css": "8.0.1"
   },
   "scripts": {
     "prepare": "node_modules/.bin/grunt",

--- a/src/audiofile.js
+++ b/src/audiofile.js
@@ -21,8 +21,6 @@ var fluid = fluid || require("infusion"),
 
     "use strict";
 
-    var atob = typeof (window) !== "undefined" ? window.atob : require("atob");
-
     /**
      * Applies the specified function in the next round of the event loop.
      */

--- a/src/web/audio-system.js
+++ b/src/web/audio-system.js
@@ -42,6 +42,9 @@ var fluid = fluid || require("infusion"),
             channelInterpretation: "discrete"
         },
 
+        // TODO: Move these into a new AudioContext component,
+        // perhaps borrowed from the SJRK's transcribing audio recorder:
+        // https://github.com/colinbdclark/transcribingRecorder/blob/componentization/src/js/proto-signaletic/audio-context.js
         modelListeners: {
             chans: {
                 funcName: "flock.webAudio.audioSystem.configureDestination",

--- a/src/web/audio-system.js
+++ b/src/web/audio-system.js
@@ -36,6 +36,38 @@ var fluid = fluid || require("infusion"),
         model: {
             rates: {
                 audio: "{that}.context.sampleRate"
+            },
+
+            channelCountMode: "explicit",
+            channelInterpretation: "discrete"
+        },
+
+        modelListeners: {
+            chans: {
+                funcName: "flock.webAudio.audioSystem.configureDestination",
+                args: [
+                    "{that}.context.destination",
+                    "channelCount",
+                    "{change}.value"
+                ]
+            },
+
+            channelCountMode: {
+                funcName: "flock.webAudio.audioSystem.configureDestination",
+                args: [
+                    "{that}.context.destination",
+                    "channelCountMode",
+                    "{change}.value"
+                ]
+            },
+
+            channelInterpretation: {
+                funcName: "flock.webAudio.audioSystem.configureDestination",
+                args: [
+                    "{that}.context.destination",
+                    "channelInterpretation",
+                    "{change}.value"
+                ]
             }
         },
 
@@ -54,13 +86,6 @@ var fluid = fluid || require("infusion"),
 
             bufferWriter: {
                 type: "flock.webAudio.bufferWriter"
-            }
-        },
-
-        listeners: {
-            "onCreate.configureDestination": {
-                funcName: "flock.webAudio.audioSystem.configureDestination",
-                args: ["{that}.context", "{that}.model.chans"]
             }
         }
     });
@@ -83,14 +108,12 @@ var fluid = fluid || require("infusion"),
         return flock.platform.browser.safari ? 2 : 1;
     };
 
-    flock.webAudio.audioSystem.configureDestination = function (context, chans) {
+    flock.webAudio.audioSystem.configureDestination = function (destination, propName, value) {
         // Safari will throw an InvalidStateError DOM Exception 11 when
         // attempting to set channelCount on the audioContext's destination.
         // TODO: Remove this conditional when Safari adds support for multiple channels.
-        if (!flock.platform.browser.safari) {
-            context.destination.channelCount = chans;
-            context.destination.channelCountMode = "explicit";
-            context.destination.channelInterpretation = "discrete";
+        if (!flock.platform.browser.safari && value !== undefined) {
+            destination[propName] = value;
         }
     };
 

--- a/src/web/output-manager.js
+++ b/src/web/output-manager.js
@@ -28,7 +28,6 @@ var fluid = fluid || require("infusion"),
 
         model: {
             isGenerating: false,
-            shouldInitSafari: flock.platform.browser.safari,
             audioSettings: {}
         },
 
@@ -64,14 +63,17 @@ var fluid = fluid || require("infusion"),
                     args: ["isGenerating", true]
                 },
                 {
-                    // TODO: Replace this with some progressive enhancement action.
+                    // Satisfy Safari and Chrome's user interaction
+                    // requirement, where it requires an AudioContext
+                    // to be explicitly resumed within a user action
+                    // event of some kind. For this to work,
+                    // the Flocking environment must be started within
+                    // a user-triggered event handler,
+                    // such as with Flocking's built-in
+                    // flock.ui.enviroPlayButton UI component.
                     priority: "last",
-                    funcName: "flock.webAudio.outputManager.safariStart",
-                    args: [
-                        "{that}",
-                        "{audioSystem}.context",
-                        "{nativeNodeManager}.scriptProcessor.node"
-                    ]
+                    "this": "{audioSystem}.context",
+                    method: "resume"
                 }
             ],
 
@@ -169,20 +171,6 @@ var fluid = fluid || require("infusion"),
                     outBuf[samp + offset] = sourceBuf[samp];
                 }
             }
-        }
-    };
-
-    flock.webAudio.outputManager.safariStart = function (that, ctx, jsNode) {
-        // Satisfy Safari's user interaction requirement,
-        // where it requires an AudioContext to be explicitly
-        // resumed within a user touch event of some kind.
-        // For this to work, the Flocking environment must be
-        // started within a user-triggered event handler,
-        // such as is the case with Flocking's built-in
-        // flock.ui.enviroPlayButton user interface component.
-        if (that.model.shouldInitSafari) {
-            ctx.resume();
-            that.applier.change("shouldInitSafari", false);
         }
     };
 }());

--- a/tests/unit/js/audiofile-tests.js
+++ b/tests/unit/js/audiofile-tests.js
@@ -15,7 +15,6 @@ var fluid = fluid || require("infusion"),
 (function () {
     "use strict";
 
-    var atob = typeof (window) !== "undefined" ? window.atob : require("atob");
     var QUnit = fluid.registerNamespace("QUnit");
     var $ = fluid.registerNamespace("jQuery");
 

--- a/tests/unit/testem.json
+++ b/tests/unit/testem.json
@@ -1,7 +1,7 @@
 {
     "test_page": "tests/unit/all-tests.html",
     "timeout": 300,
-    "skip": "PhantomJS,IE",
+    "skip": "PhantomJS,IE,Headless Chrome",
     "browser_args": {
         "Chrome": [
             "--autoplay-policy=no-user-gesture-required"


### PR DESCRIPTION
Fixes gh-265 by always resuming the audiocontext when its enviro is started.

Fixes gh-266 by adding model listeners for channel-related settings to the Web Audio AudioSystem.

Updates to latest third-party dependencies (except Testem, which is causing issues on my system).