### PR TITLE
Resolves gh-271: Provides a new onPortsChanged event.

### DIFF
--- a/src/ui/midi/midi-port-selector/js/midi-port-selector.js
+++ b/src/ui/midi/midi-port-selector/js/midi-port-selector.js
@@ -123,8 +123,8 @@ var fluid = fluid || require("infusion"),
         },
 
         markup: {
-            label: "<label for='%selectBoxID'>%selectBoxLabel:</label>",
-            selectBox: "<select class='flock-midi-selector-selectBox' id='%selectBoxId'></select>",
+            label: "<label for='%selectBoxID'>%selectBoxLabel</label>",
+            selectBox: "<select class='flock-midi-selector-selectBox' id='%selectBoxID'></select>",
             refreshButton: "<button name='refresh'>%refreshButtonLabel</button>"
         },
 
@@ -135,7 +135,7 @@ var fluid = fluid || require("infusion"),
         },
 
         strings: {
-            selectBoxLabel: "MIDI Port",
+            selectBoxLabel: "MIDI Port:",
             refreshButtonLabel: "Refresh"
         },
 

--- a/src/ui/selectbox/js/selectbox.js
+++ b/src/ui/selectbox/js/selectbox.js
@@ -85,8 +85,17 @@ var fluid = fluid || require("infusion"),
         },
 
         modelListeners: {
-            groups: "{that}.refreshView()",
-            options: "{that}.refreshView()"
+            groups: {
+                namespace: "refreshView",
+                excludeSource: "init",
+                func: "{that}.refreshView"
+            },
+
+            options: {
+                namespace: "refreshView",
+                excludeSource: "init",
+                func: "{that}.refreshView"
+            }
         },
 
         listeners: {
@@ -95,6 +104,7 @@ var fluid = fluid || require("infusion"),
                 method: "change",
                 args: ["{that}.handleChange"]
             },
+
             "onCreate.fireOnRender": {
                 priority: "after:bindChangeHandler",
                 func: "{that}.events.onRender.fire"

--- a/src/web/midi.js
+++ b/src/web/midi.js
@@ -368,7 +368,8 @@ var fluid = fluid || require("infusion"),
             onAccessGranted: null,
             onAccessError: null,
             onReady: null,
-            onPortsAvailable: null
+            onPortsAvailable: null,
+            onPortsChanged: null
         },
 
         listeners: {
@@ -379,6 +380,16 @@ var fluid = fluid || require("infusion"),
             "onAccessGranted.setAccess": {
                 func: "flock.midi.system.setAccess",
                 args: ["{that}", "{arguments}.0"]
+            },
+
+            "onAccessGranted.bindOnPortsChanged": {
+                priority: "after:setAccess",
+                "this": "{that}.access",
+                method: "addEventListener",
+                args: [
+                    "statechange",
+                    "{that}.events.onPortsChanged.fire"
+                ]
             },
 
             "onAccessGranted.refreshPorts": {
@@ -395,7 +406,9 @@ var fluid = fluid || require("infusion"),
             "onAccessError.logError": {
                 funcName: "fluid.log",
                 args: [fluid.logLevel.WARN, "MIDI Access Error: ", "{arguments}.0"]
-            }
+            },
+
+            "onPortsChanged.refreshPorts": "{that}.refreshPorts()"
 
             // TODO: Provide an onDestroy listener
             // that will close any ports that are open.


### PR DESCRIPTION
Also updates the flock.ui.midiSelector component to automatically rerender itself when ports change.
Minor bug fixing and namespacing in flock.ui.midiSelector.

Note that @the-t-in-rtf has some work on a better, auto-refreshing MIDI selector component, but it still needs some work and should be harmonized with the work in the new [flocking-midi](https://github.com/colinbdclark/flocking-midi/tree/gh-1) repository. My impression is that the <code>flock.ui.selectBox</code> component should also be rewritten from scratch in a proper model idiom, perhaps with the use of gpii.binder.

But for now, this pull request should provide the requisite features requested by users such as the developer of Bubbles. :)